### PR TITLE
Remove Unused http_proxy and https_proxy Variables

### DIFF
--- a/cxxprocessor/Dockerfile
+++ b/cxxprocessor/Dockerfile
@@ -16,12 +16,6 @@
 FROM ubuntu:xenial
 
 RUN \
- if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
-  http_proxy=$HTTP_PROXY; \
- fi; \
- if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
-  https_proxy=$HTTPS_PROXY; \
- fi; \
  apt-get update; \
  apt-get install curl -y; \
  echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \

--- a/javaprocessor/Dockerfile
+++ b/javaprocessor/Dockerfile
@@ -16,12 +16,6 @@
 FROM ubuntu:xenial
 
 RUN \
- if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
-  http_proxy=$HTTP_PROXY; \
- fi; \
- if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
-  https_proxy=$HTTPS_PROXY; \
- fi; \
  apt-get update; \
  apt-get install curl -y; \
  echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \

--- a/pyclient/Dockerfile
+++ b/pyclient/Dockerfile
@@ -18,12 +18,6 @@ FROM ubuntu:xenial
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
- if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
-  http_proxy=$HTTP_PROXY; \
- fi; \
- if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
-  https_proxy=$HTTPS_PROXY; \
- fi; \
  apt-get update; \
  apt-get install curl -y; \
  echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \

--- a/pyprocessor/Dockerfile
+++ b/pyprocessor/Dockerfile
@@ -16,12 +16,6 @@
 FROM ubuntu:xenial
 
 RUN \
- if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
-  http_proxy=$HTTP_PROXY; \
- fi; \
- if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
-  https_proxy=$HTTPS_PROXY; \
- fi; \
  apt-get update; \
  apt-get install curl -y; \
  curl -sSL 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x8AA7AF1F1091A5FD' | apt-key add - \


### PR DESCRIPTION
http_proxy and https_proxy are no longer used for apt-key now that curl
is used to retrieve the key.

Signed-off-by: danintel <daniel.anderson@intel.com>