### PR TITLE
Fix Genesis Block Creation in Sawtooth 1.2

### DIFF
--- a/docker-compose-cxx.yaml
+++ b/docker-compose-cxx.yaml
@@ -52,7 +52,7 @@ services:
 
   sawtooth-rest-api:
     container_name: rest-api
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     expose:
       - 8008
     ports:
@@ -65,14 +65,14 @@ services:
         --bind sawtooth-rest-api:8008
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator
     command: settings-tp -vv --connect tcp://validator:4004
 
   validator:
     container_name: validator
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     expose:
       - 4004
     ports:
@@ -80,10 +80,14 @@ services:
     command: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
-        sawadm keygen &&
-        sawtooth keygen my_key &&
-        sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
-        sawadm genesis config-genesis.batch
+           sawadm keygen &&
+           sawtooth keygen my_key &&
+           sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+           sawset proposal create -k /root/.sawtooth/keys/my_key.priv \
+              sawtooth.consensus.algorithm.name=Devmode \
+              sawtooth.consensus.algorithm.version=0.1 \
+              -o config.batch &&
+           sawadm genesis config-genesis.batch config.batch
         fi;
         sawtooth-validator -vvv \
           --endpoint tcp://validator:8800 \
@@ -93,7 +97,7 @@ services:
       "
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default

--- a/docker-compose-go-event-client.yaml
+++ b/docker-compose-go-event-client.yaml
@@ -70,7 +70,7 @@ services:
 
   sawtooth-rest-api:
     container_name: rest-api
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     expose:
       - 8008
     ports:
@@ -83,14 +83,14 @@ services:
         --bind sawtooth-rest-api:8008
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator
     command: settings-tp -vv --connect tcp://validator:4004
 
   validator:
     container_name: validator
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     expose:
       - 4004
     ports:
@@ -98,10 +98,14 @@ services:
     command: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
-        sawadm keygen &&
-        sawtooth keygen my_key &&
-        sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
-        sawadm genesis config-genesis.batch
+           sawadm keygen &&
+           sawtooth keygen my_key &&
+           sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+           sawset proposal create -k /root/.sawtooth/keys/my_key.priv \
+              sawtooth.consensus.algorithm.name=Devmode \
+              sawtooth.consensus.algorithm.version=0.1 \
+              -o config.batch &&
+           sawadm genesis config-genesis.batch config.batch
         fi;
         sawtooth-validator -vvv \
           --endpoint tcp://validator:8800 \
@@ -111,7 +115,7 @@ services:
       "
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default

--- a/docker-compose-java-v1.yaml
+++ b/docker-compose-java-v1.yaml
@@ -55,13 +55,13 @@ services:
     stop_signal: SIGKILL
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator-1
     command: settings-tp -vv --connect tcp://validator:4004
 
   rest-api:
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     container_name: rest-api
     expose:
       - 8008
@@ -74,7 +74,7 @@ services:
     stop_signal: SIGKILL
 
   validator-registry-tp:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:1.1
+    image: hyperledger/sawtooth-poet-validator-registry-tp:1.2
     container_name: sawtooth-poet-validator-registry-tp
     expose:
       - 4004
@@ -84,7 +84,7 @@ services:
     stop_signal: SIGKILL
 
   validator-1:
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     container_name: validator-1
     expose:
       - 4004
@@ -129,7 +129,7 @@ services:
     stop_signal: SIGKILL
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default

--- a/docker-compose-java-v2.yaml
+++ b/docker-compose-java-v2.yaml
@@ -55,13 +55,13 @@ services:
     stop_signal: SIGKILL
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator-2
     command: settings-tp -vv --connect tcp://validator:4004
 
   rest-api:
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     container_name: rest-api
     expose:
       - 8008
@@ -74,7 +74,7 @@ services:
     stop_signal: SIGKILL
 
   validator-registry-tp:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:1.1
+    image: hyperledger/sawtooth-poet-validator-registry-tp:1.2
     container_name: sawtooth-poet-validator-registry-tp
     expose:
       - 4004
@@ -84,7 +84,7 @@ services:
     stop_signal: SIGKILL
 
   validator-2:
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     container_name: sawtooth-validator-default-2
     expose:
       - 4004
@@ -109,7 +109,7 @@ services:
     stop_signal: SIGKILL
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default

--- a/docker-compose-java-v3.yaml
+++ b/docker-compose-java-v3.yaml
@@ -55,13 +55,13 @@ services:
     stop_signal: SIGKILL
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator-3
     command: settings-tp -vv --connect tcp://validator:4004
 
   rest-api:
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     container_name: rest-api
     expose:
       - 8008
@@ -74,7 +74,7 @@ services:
     stop_signal: SIGKILL
 
   validator-registry-tp:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:1.1
+    image: hyperledger/sawtooth-poet-validator-registry-tp:1.2
     container_name: sawtooth-poet-validator-registry-tp
     expose:
       - 4004
@@ -84,7 +84,7 @@ services:
     stop_signal: SIGKILL
 
   validator-3:
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     container_name: validator-3
     expose:
       - 4004
@@ -109,7 +109,7 @@ services:
     stop_signal: SIGKILL
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default

--- a/docker-compose-java.yaml
+++ b/docker-compose-java.yaml
@@ -57,7 +57,7 @@ services:
 
   sawtooth-rest-api:
     container_name: rest-api
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     expose:
       - 8008
     ports:
@@ -70,14 +70,14 @@ services:
         --bind sawtooth-rest-api:8008
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator
     command: settings-tp -vv --connect tcp://validator:4004
 
   validator:
     container_name: validator
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     expose:
       - 4004
     ports:
@@ -85,10 +85,14 @@ services:
     command: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
-        sawadm keygen &&
-        sawtooth keygen my_key &&
-        sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
-        sawadm genesis config-genesis.batch
+           sawadm keygen &&
+           sawtooth keygen my_key &&
+           sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+           sawset proposal create -k /root/.sawtooth/keys/my_key.priv \
+              sawtooth.consensus.algorithm.name=Devmode \
+              sawtooth.consensus.algorithm.version=0.1 \
+              -o config.batch &&
+           sawadm genesis config-genesis.batch config.batch
         fi;
         sawtooth-validator -vvv \
           --endpoint tcp://validator:8800 \
@@ -98,7 +102,7 @@ services:
       "
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,10 +21,6 @@ services:
     build:
       context: .
       dockerfile: ./pyprocessor/Dockerfile
-      args:
-        - http_proxy
-        - https_proxy
-        - no_proxy
     depends_on:
       - validator
     volumes:
@@ -35,14 +31,6 @@ services:
     build:
       context: .
       dockerfile: ./pyclient/Dockerfile
-      args:
-        - http_proxy
-        - https_proxy
-        - no_proxy
-    environment:
-      - 'http_proxy=${http_proxy}'
-      - 'https_proxy=${https_proxy}'
-      - 'no_proxy=rest-api,validator,${no_proxy}'
     volumes:
       - '.:/project/cookiejar/'
     depends_on:
@@ -52,7 +40,7 @@ services:
 
   sawtooth-rest-api:
     container_name: rest-api
-    image: hyperledger/sawtooth-rest-api:1.1
+    image: hyperledger/sawtooth-rest-api:1.2
     expose:
       - 8008
     ports:
@@ -65,14 +53,14 @@ services:
         --bind sawtooth-rest-api:8008
 
   settings-tp:
-    image: hyperledger/sawtooth-settings-tp:1.1
+    image: hyperledger/sawtooth-settings-tp:1.2
     depends_on:
       - validator
     command: settings-tp -vv --connect tcp://validator:4004
 
   validator:
     container_name: validator
-    image: hyperledger/sawtooth-validator:1.1
+    image: hyperledger/sawtooth-validator:1.2
     expose:
       - 4004
     ports:
@@ -80,10 +68,14 @@ services:
     command: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
-        sawadm keygen &&
-        sawtooth keygen my_key &&
-        sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
-        sawadm genesis config-genesis.batch
+           sawadm keygen &&
+           sawtooth keygen my_key &&
+           sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+           sawset proposal create -k /root/.sawtooth/keys/my_key.priv \
+              sawtooth.consensus.algorithm.name=Devmode \
+              sawtooth.consensus.algorithm.version=0.1 \
+              -o config.batch &&
+           sawadm genesis config-genesis.batch config.batch
         fi;
         sawtooth-validator -vvv \
           --endpoint tcp://validator:8800 \
@@ -93,7 +85,7 @@ services:
       "
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    image: hyperledger/sawtooth-devmode-engine-rust:1.2
     ports:
       - '5050:5050'
     container_name: sawtooth-devmode-engine-rust-default


### PR DESCRIPTION
Sawtooth 1.2.3 apparently now requires the consensus algorithm and mode
to be specified. The message showing the regression is:

```
Error: The following setting(s) are required at genesis,
but were not included in the genesis batches:
['sawtooth.consensus.algorithm.name', 'sawtooth.consensus.algorithm.version']
```

Also upgrade to use Sawtooth 1.2 (from 1.1)

Signed-off-by: danintel <daniel.anderson@intel.com>